### PR TITLE
obsffmpeg: Add support for I444 video format for av1 encoders

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-av1.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-av1.c
@@ -59,6 +59,10 @@ static void av1_video_info(void *data, struct video_scale_info *info)
 	case VIDEO_FORMAT_P010:
 		info->format = VIDEO_FORMAT_I010;
 		break;
+	/* Allow 444 for av1 encoders in Standard recording settings */
+	case VIDEO_FORMAT_I444: 
+		info->format = VIDEO_FORMAT_I444;
+		break;
 	default:
 		info->format = VIDEO_FORMAT_I420;
 	}


### PR DESCRIPTION
### Description

The standard recording AV1 encoder implementation in OBS only allows up to I420 colorspace and will ignore the I444 setting, The AOM AV1 encoder does support I444 (yuv444p), even though the SVT AV1 encoder does not. This will add in support for I444 when selected.

This issue has pointed out the cause in the code.
https://github.com/obsproject/obs-studio/issues/10463

This is a workaround for trying to use custom output which I have since learned is less robust and crashes OBS when the encoder is too slow.
https://github.com/obsproject/obs-studio/issues/7472

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

